### PR TITLE
views: Implement a terminal-splitting `View`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,10 @@ configure_file(${VIEW_SRC_DIR}/version.h.in ${CMAKE_CURRENT_BINARY_DIR}/gen/vers
 
 # Source files
 set(VIEW_SRC_LIST
-    ${VIEW_SRC_DIR}/engine.cpp
     ${VIEW_SRC_DIR}/frame_view.cpp
+    ${VIEW_SRC_DIR}/split_view.cpp
     ${VIEW_SRC_DIR}/text_view.cpp
+    ${VIEW_SRC_DIR}/engine.cpp
     ${VIEW_SRC_DIR}/event.cpp
     ${VIEW_SRC_DIR}/memory_pane.cpp
     ${VIEW_SRC_DIR}/ncurses_pane.cpp
@@ -53,6 +54,7 @@ set(VIEW_SRC_LIST
 # Test files
 set(VIEW_TEST_LIST
     ${VIEW_TEST_DIR}/frame_view_test.cpp
+    ${VIEW_TEST_DIR}/split_view_test.cpp
     ${VIEW_TEST_DIR}/text_view_test.cpp
 )
 
@@ -71,5 +73,9 @@ target_link_libraries(view-tests view gtest_main)
 add_test(unit-tests view-tests)
 
 # Examples
+# TODO (whalbawi): Conditionally build examples
+add_executable(split ${VIEW_EXAMPLES_DIR}/split.cpp)
+target_link_libraries(split view)
+
 add_executable(text ${VIEW_EXAMPLES_DIR}/text.cpp)
 target_link_libraries(text view)

--- a/examples/split.cpp
+++ b/examples/split.cpp
@@ -1,0 +1,24 @@
+#include "view/engine.h"
+#include "view/frame_view.h"
+#include "view/split_view.h"
+#include "view/text_view.h"
+
+int main(int argc, char** argv) {
+    // Left View
+    auto left_text = std::make_shared<view::TextView>();
+    auto left_frame = std::make_shared<view::FrameView>(left_text);
+    // Right View
+    auto right_text = std::make_shared<view::TextView>();
+    auto right_frame = std::make_shared<view::FrameView>(right_text);
+    // Present both views using a `SplitView`
+    auto main_view = std::make_shared<view::SplitView>(left_frame, right_frame, true, 1, 2);
+
+    left_text->set_content("Left View");
+    right_text->set_content("Right View");
+
+    view::Engine engine{main_view};
+
+    engine.run();
+
+    return 0;
+}

--- a/include/view/engine.h
+++ b/include/view/engine.h
@@ -34,9 +34,9 @@ class Engine {
     void run();
 
   private:
-    std::shared_ptr<View> main_view;
-
     void refresh();
+
+    std::shared_ptr<View> main_view;
 };
 
 } // namespace view

--- a/include/view/event.h
+++ b/include/view/event.h
@@ -3,6 +3,7 @@
 
 namespace view {
 
+class ComboKeyEvent;
 class TerminalResizeEvent;
 
 // `Event` represents an input to, or a change in state of the terminal.
@@ -11,6 +12,7 @@ class Event {
     // `Visitor` facilitates prescribing how a class should react to each type of `Event`.
     class Visitor {
       public:
+        virtual bool visit_combo_key_event(const ComboKeyEvent* event);
         virtual bool visit_terminal_resize_event(const TerminalResizeEvent* event);
     };
 
@@ -18,6 +20,24 @@ class Event {
 
     // Dispatches the correct `Visitor` method.
     virtual bool accept(Visitor* visitor) const = 0;
+};
+
+// `ComboKeyEvent` represents the pressing of a combination of two keys in which one is a function
+// key: control, shift, alt, etc. The combination is described by the pair `function_key` and `key`,
+class ComboKeyEvent : public Event {
+  public:
+    enum class FunctionKey {
+        SHIFT,
+    };
+
+    enum class Key { LEFT, RIGHT };
+
+    ComboKeyEvent(FunctionKey function_key, Key key);
+
+    bool accept(Visitor* visitor) const override;
+
+    const FunctionKey function_key;
+    const Key key;
 };
 
 // `TerminalResizeEvent` represents the resizing of the terminal.

--- a/include/view/split_view.h
+++ b/include/view/split_view.h
@@ -1,0 +1,51 @@
+#ifndef VIEW_SPLIT_VIEW_H_
+#define VIEW_SPLIT_VIEW_H_
+
+#include <memory>
+
+#include "event.h"
+#include "view.h"
+
+namespace view {
+
+// `SplitView` presents two `View`s next to one another, either vertically or horizontally.
+// It delivers `Event`s to one and only one of the two `View`s: the one that is in focus.
+// Initially, the left (top) `View` of a vertical (horizontal) `SplitView`.
+// The `View` in focus can be changed once a "shift-left" or "shift-right" key combination
+// is received by `SplitView`.
+class SplitView : public View {
+  public:
+    // Constructs a `SplitView` with the specified geometry.
+    // `vertical`: The child `View`s are side-by-side if only and if this value is true.
+    // The child `Views` are scaled so that the width (height) ratio is `scale_first`:`scale_second`
+    // for a vertical (horizontal) `SplitView`.
+    //
+    // Note: In general, child `View`s must not process focus-changing keys unless they themselves
+    //       are instances of `SplitView`. This allows `SplitView`s to compose naturally where
+    //       the change in focus transfers from the children to the parent.
+    SplitView(std::shared_ptr<View> first,
+              std::shared_ptr<View> second,
+              bool vertical = true,
+              size_t scale_first = 1,
+              size_t scale_second = 1);
+
+    bool on_event(const Event* event) override;
+
+    bool visit_combo_key_event(const ComboKeyEvent* event) override;
+
+  protected:
+    void render(Pane* pane) override;
+
+  private:
+    const bool vertical;
+    const size_t scale_first;
+    const size_t scale_second;
+    const std::shared_ptr<View> first;
+    const std::shared_ptr<View> second;
+
+    bool first_in_focus;
+};
+
+} // namespace view
+
+#endif // VIEW_SPLIT_VIEW_H_

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -15,6 +15,7 @@ WINDOW* root_window;
 Engine::Engine(std::shared_ptr<View> main_view) : main_view(std::move(main_view)) {
     setlocale(LC_ALL, ""); // Needed for proper rendering of border characters
     root_window = initscr();
+    keypad(root_window, true);
     curs_set(0); // Hide the cursor
     noecho();    // Do not echo input characters
 }
@@ -28,6 +29,14 @@ void Engine::run() {
     while ((ch = wgetch(root_window)) != -1) {
         std::unique_ptr<Event> event{};
         switch (ch) {
+        case KEY_SLEFT:
+            event = std::make_unique<ComboKeyEvent>(ComboKeyEvent::FunctionKey::SHIFT,
+                                                    ComboKeyEvent::Key::LEFT);
+            break;
+        case KEY_SRIGHT:
+            event = std::make_unique<ComboKeyEvent>(ComboKeyEvent::FunctionKey::SHIFT,
+                                                    ComboKeyEvent::Key::RIGHT);
+            break;
         case KEY_RESIZE:
             refresh();
             break;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -2,9 +2,20 @@
 
 namespace view {
 
-// Default implementation
+// Default implementations
+bool Event::Visitor::visit_combo_key_event(const ComboKeyEvent* event) {
+    return false;
+}
+
 bool Event::Visitor::visit_terminal_resize_event(const TerminalResizeEvent* event) {
     return false;
+}
+
+ComboKeyEvent::ComboKeyEvent(FunctionKey function_key, Key key)
+    : function_key(function_key), key(key) {}
+
+bool ComboKeyEvent::accept(Visitor* visitor) const {
+    return visitor->visit_combo_key_event(this);
 }
 
 bool TerminalResizeEvent::accept(Visitor* visitor) const {

--- a/src/memory_pane.h
+++ b/src/memory_pane.h
@@ -11,11 +11,11 @@ namespace view {
 // `MemoryPane` emulates a fixed-size terminal, where every character is initially null ('\0').
 class MemoryPane : public Pane {
   public:
-    std::vector<std::wstring> rows; // Exposed for testing
-
     MemoryPane(size_t height, size_t width);
 
     void put_char(wchar_t ch, size_t pos_y, size_t pos_x) override;
+
+    std::vector<std::wstring> rows; // Exposed for testing
 
   private:
     Pane* clone() override;

--- a/src/ncurses_pane.cpp
+++ b/src/ncurses_pane.cpp
@@ -3,7 +3,6 @@
 #include "ncurses.h"
 
 namespace view {
-
 NCursesPane::NCursesPane(WINDOW* root_window)
     : root_window(root_window), Pane(0, 0, getmaxy(root_window), getmaxx(root_window)) {}
 

--- a/src/split_view.cpp
+++ b/src/split_view.cpp
@@ -1,0 +1,75 @@
+#include "view/split_view.h"
+
+#include "pane.h"
+
+namespace view {
+
+SplitView::SplitView(std::shared_ptr<View> first,
+                     std::shared_ptr<View> second,
+                     bool vertical,
+                     size_t scale_first,
+                     size_t scale_second)
+    : first(std::move(first)),
+      second(std::move(second)),
+      vertical(vertical),
+      first_in_focus(true),
+      scale_first(scale_first),
+      scale_second(scale_second) {}
+
+bool SplitView::on_event(const Event* event) {
+    if (first_in_focus ? first->on_event(event) : second->on_event(event)) return true;
+
+    return event->accept(this);
+}
+
+bool SplitView::visit_combo_key_event(const ComboKeyEvent* event) {
+    if (event->function_key != ComboKeyEvent::FunctionKey::SHIFT) return false;
+
+    switch (event->key) {
+    case ComboKeyEvent::Key::LEFT:
+        if (first_in_focus) return false;
+        break;
+    case ComboKeyEvent::Key::RIGHT:
+        if (!first_in_focus) return false;
+        break;
+    default:
+        return false;
+    }
+
+    first_in_focus = !first_in_focus;
+
+    return true;
+}
+
+void SplitView::render(Pane* pane) {
+    size_t height_first;
+    size_t height_second;
+    size_t width_first;
+    size_t width_second;
+    size_t off_y_second;
+    size_t off_x_second;
+    size_t scale = scale_first + scale_second;
+    if (vertical) {
+        height_first = pane->get_height();
+        width_first = pane->get_width() * scale_first / scale;
+        height_second = pane->get_height();
+        width_second = pane->get_width() - width_first;
+        off_y_second = 0;
+        off_x_second = width_first;
+    } else {
+        height_first = pane->get_height() * scale_first / scale;
+        width_first = pane->get_width();
+        height_second = pane->get_height() - height_first;
+        width_second = pane->get_width();
+        off_y_second = height_first;
+        off_x_second = 0;
+    }
+
+    Pane* pane_first = pane->limit(0, 0, height_first, width_first);
+    Pane* pane_second = pane->limit(off_y_second, off_x_second, height_second, width_second);
+
+    first->render(pane_first);
+    second->render(pane_second);
+}
+
+} // namespace view

--- a/test/frame_view_test.cpp
+++ b/test/frame_view_test.cpp
@@ -18,7 +18,7 @@ TEST_F(FrameViewTest, Render) {
     for (int i = 0; i < pane.rows.size(); ++i) {
         std::wstring& row = pane.rows[i];
         for (int j = 0; j < row.size(); ++j) {
-            // `FramView` only touches the `Pane`'s border
+            // `FrameView` should only touch the `Pane`'s border
             if (i == 0 || i == pane.rows.size() - 1 || j == 0 || j == row.size() - 1) {
                 ASSERT_NE(row[j], L'\0');
             } else {

--- a/test/split_view_test.cpp
+++ b/test/split_view_test.cpp
@@ -1,0 +1,65 @@
+#include "view/split_view.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "memory_pane.h"
+#include "view/view.h"
+
+class TestEvent : public view::Event {
+    bool accept(Visitor* visitor) const override {
+        return true;
+    }
+};
+
+class ReactiveView : public view::View {
+  public:
+    // Explicitly reject combo key events. This way, we know that any event delivered to the `View`
+    // must have been a `TestEvent`.
+    bool visit_combo_key_event(const view::ComboKeyEvent* event) override {
+        return false;
+    }
+
+    bool on_event(const view::Event* event) override {
+        return touched = event->accept(this);
+    }
+
+    void render(view::Pane* pane) override {}
+
+    bool touched{};
+};
+
+class SplitViewTest : public ::testing::Test {
+  protected:
+    SplitViewTest()
+        : view1(std::make_shared<ReactiveView>()),
+          view2(std::make_shared<ReactiveView>()),
+          view(view1, view2) {}
+    std::shared_ptr<ReactiveView> view1;
+    std::shared_ptr<ReactiveView> view2;
+
+    view::SplitView view;
+    view::MemoryPane pane{50, 80};
+};
+
+TEST_F(SplitViewTest, HandlesEventFirstInFocus) {
+    TestEvent test_event{};
+    view.on_event(&test_event);
+
+    ASSERT_TRUE(view1->touched);
+    ASSERT_FALSE(view2->touched);
+}
+
+TEST_F(SplitViewTest, HandlesEventSecondInFocus) {
+    // First shift focus to the second view,
+    view::ComboKeyEvent shift_focus_event{view::ComboKeyEvent::FunctionKey::SHIFT,
+                                          view::ComboKeyEvent::Key::RIGHT};
+    view.on_event(&shift_focus_event);
+    // now send a test event,
+    TestEvent test_event{};
+    view.on_event(&test_event);
+    // and make sure it's delivered to the correct view.
+    ASSERT_FALSE(view1->touched);
+    ASSERT_TRUE(view2->touched);
+}


### PR DESCRIPTION
Introduce a `SplitView` construct the facilitates displaying one `View`
next to another. There's alway one and only one child `View` in focus
per `SplitView`, to which terminal events are delivered. The `View` in
focus can be changed using a combo-key. As such, a child `View` are
discouraged from processing these events unless it is a `SplitView`.
Following this rule allows `SplitView`s compose recursively and can be
traversed across naturally.